### PR TITLE
Default right-matrix display and charging animations

### DIFF
--- a/ismf_battery_monitor/animations.py
+++ b/ismf_battery_monitor/animations.py
@@ -111,7 +111,7 @@ def plugged_in(controller, *, brightness: int | None = None, frame_duration: flo
 
 
 def _play_battery_direction_animation(controller, *, charging: bool, brightness: int | None = None,
-                                      frame_duration: float = 1.0) -> None:
+                                      frame_duration: float = 1.0, loop: bool = False) -> None:
     ensure_thread_safety(controller)
     controller.clear()
     prev_brightness = getattr(controller, 'brightness', None)
@@ -121,6 +121,7 @@ def _play_battery_direction_animation(controller, *, charging: bool, brightness:
     filename = 'batt_up.json' if charging else 'batt_down.json'
     ani = _load_animation_from_package(filename)
     ani.set_all_frame_durations(frame_duration)
+    ani.loop = loop
     ani.play(controller)
 
     if prev_brightness is not None:
@@ -128,22 +129,24 @@ def _play_battery_direction_animation(controller, *, charging: bool, brightness:
 
 
 def play_batt_up_animation(controller, *, brightness: int | None = None,
-                           frame_duration: float = 1.0, **_: object) -> None:
+                           frame_duration: float = 1.0, loop: bool = False, **_: object) -> None:
     _play_battery_direction_animation(
         controller,
         charging=True,
         brightness=brightness,
         frame_duration=frame_duration,
+        loop=loop
     )
 
 
 def play_batt_down_animation(controller, *, brightness: int | None = None,
-                             frame_duration: float = 1.0, **_: object) -> None:
+                             frame_duration: float = 1.0,  loop: bool = False, **_: object) -> None:
     _play_battery_direction_animation(
         controller,
         charging=False,
         brightness=brightness,
         frame_duration=frame_duration,
+        loop=loop
     )
 
 

--- a/ismf_battery_monitor/animations.py
+++ b/ismf_battery_monitor/animations.py
@@ -110,6 +110,43 @@ def plugged_in(controller, *, brightness: int | None = None, frame_duration: flo
         controller.set_brightness(prev_brightness)
 
 
+def _play_battery_direction_animation(controller, *, charging: bool, brightness: int | None = None,
+                                      frame_duration: float = 1.0) -> None:
+    ensure_thread_safety(controller)
+    controller.clear()
+    prev_brightness = getattr(controller, 'brightness', None)
+    if brightness is not None:
+        controller.set_brightness(brightness)
+
+    filename = 'batt_up.json' if charging else 'batt_down.json'
+    ani = _load_animation_from_package(filename)
+    ani.set_all_frame_durations(frame_duration)
+    ani.play(controller)
+
+    if prev_brightness is not None:
+        controller.set_brightness(prev_brightness)
+
+
+def play_batt_up_animation(controller, *, brightness: int | None = None,
+                           frame_duration: float = 1.0, **_: object) -> None:
+    _play_battery_direction_animation(
+        controller,
+        charging=True,
+        brightness=brightness,
+        frame_duration=frame_duration,
+    )
+
+
+def play_batt_down_animation(controller, *, brightness: int | None = None,
+                             frame_duration: float = 1.0, **_: object) -> None:
+    _play_battery_direction_animation(
+        controller,
+        charging=False,
+        brightness=brightness,
+        frame_duration=frame_duration,
+    )
+
+
 def drain_progress(
         controller=None,
         check_interval=3,

--- a/ismf_battery_monitor/scenes.py
+++ b/ismf_battery_monitor/scenes.py
@@ -33,6 +33,7 @@ def get_composite_scene_for_battery_level(
         digits_on_bottom: Optional[bool] = None,
         invert_on_overlap: bool = True,
         charging_state: Optional[bool] = None,
+        show_charge_indicator: bool = True,
 ):
     """
     Returns a CompositeGrid scene for the given battery percentage.
@@ -56,7 +57,8 @@ def get_composite_scene_for_battery_level(
 
     fg.draw_digits(p, bottom_of_grid=on_bottom)
 
-    _apply_charge_indicator(fg, charging_state)
+    if show_charge_indicator:
+        _apply_charge_indicator(fg, charging_state)
 
     return CompositeGrid(
         background=bg,

--- a/ismf_battery_monitor/scripts/battery_monitor/main.py
+++ b/ismf_battery_monitor/scripts/battery_monitor/main.py
@@ -92,6 +92,7 @@ class BatteryMonitorCLI(Loggable):
         self.stop_event = Event()
 
         self.controllers: List[object] = []
+        self.animation_controller: Optional[object] = None
         self.last_charging_state: Optional[bool] = None
 
         self.exit_handler = ExitCallHandler()
@@ -159,7 +160,11 @@ class BatteryMonitorCLI(Loggable):
 
         log.debug("Controllers after filtering: %s", controllers)
 
-        for controller in controllers:
+        controllers_to_prepare = list(controllers)
+        if self.animation_controller is not None and self.animation_controller not in controllers_to_prepare:
+            controllers_to_prepare.append(self.animation_controller)
+
+        for controller in controllers_to_prepare:
             log.debug("Preparing controller: %s", controller)
 
             if self.args.brightness is not None:
@@ -176,18 +181,25 @@ class BatteryMonitorCLI(Loggable):
                 log.debug("Enabling breathing for controller: %s", controller)
                 self._toggle_flag(controller, "breathing", True)
 
-        log.debug("Controllers prepared: %s", controllers)
+        log.debug("Controllers prepared: %s", controllers_to_prepare)
         return controllers
 
     def _filter_controllers(self, controllers: List[object]) -> List[object]:
+        left = find_leftmost(controllers)
+        right = find_rightmost(controllers)
+
         if getattr(self.args, "left_only", False):
-            selected = [find_leftmost(controllers)]
-        elif getattr(self.args, "right_only", False) or not (
-            getattr(self.args, "left_only", False) or getattr(self.args, "right_only", False)
-        ):
-            selected = [find_rightmost(controllers)]
+            selected = [left]
+            self.animation_controller = None
+        elif getattr(self.args, "right_only", False):
+            selected = [right]
+            self.animation_controller = None
         else:
-            selected = controllers
+            selected = [right or left]
+            if left is not None and right is not None and left is not right:
+                self.animation_controller = left if (right or left) is right else right
+            else:
+                self.animation_controller = None
 
         return [ctrl for ctrl in selected if ctrl is not None]
 
@@ -287,9 +299,7 @@ class BatteryMonitorCLI(Loggable):
         if not (
             getattr(self.args, "show_animations", False)
             and self.controllers
-            and self.last_charging_state is not None
             and charging is not None
-            and charging != self.last_charging_state
         ):
             log.debug("Not running animation: %s", charging)
             return
@@ -304,12 +314,17 @@ class BatteryMonitorCLI(Loggable):
             "direction": args.scroll_direction,
         }
 
-        loop = False
-        if len(self.controllers) > 1:
-            log.debug("Found multiple controllers, running animation on leftmost")
-            loop = True
-            controller = find_leftmost(self.controllers)
+        controller = self.animation_controller
+        loop = controller is not None
+        if controller is not None:
+            if charging == self.last_charging_state:
+                log.debug("Animation controller already showing state: %s", charging)
+                return
+            log.debug("Found secondary controller, running animation on it")
         else:
+            if self.last_charging_state is None or charging == self.last_charging_state:
+                log.debug("Not running animation on primary controller")
+                return
             log.debug("Found single controller, running animation on it")
             controller = self.controllers[0]
 

--- a/ismf_battery_monitor/scripts/battery_monitor/main.py
+++ b/ismf_battery_monitor/scripts/battery_monitor/main.py
@@ -160,9 +160,7 @@ class BatteryMonitorCLI(Loggable):
 
         log.debug("Controllers after filtering: %s", controllers)
 
-        controllers_to_prepare = list(controllers)
-        if self.animation_controller is not None and self.animation_controller not in controllers_to_prepare:
-            controllers_to_prepare.append(self.animation_controller)
+        controllers_to_prepare = self._get_active_controllers(controllers)
 
         for controller in controllers_to_prepare:
             log.debug("Preparing controller: %s", controller)
@@ -188,20 +186,26 @@ class BatteryMonitorCLI(Loggable):
         left = find_leftmost(controllers)
         right = find_rightmost(controllers)
 
-        if getattr(self.args, "left_only", False):
-            selected = [left]
-            self.animation_controller = None
-        elif getattr(self.args, "right_only", False):
-            selected = [right]
-            self.animation_controller = None
-        else:
-            selected = [right or left]
-            if left is not None and right is not None and left is not right:
-                self.animation_controller = left if (right or left) is right else right
-            else:
-                self.animation_controller = None
+        primary = None
+        animation = None
 
-        return [ctrl for ctrl in selected if ctrl is not None]
+        if getattr(self.args, "left_only", False):
+            primary = left
+        elif getattr(self.args, "right_only", False):
+            primary = right
+        else:
+            primary = right or left
+            if left is not None and right is not None and left is not right:
+                animation = left if primary is right else right
+
+        self.animation_controller = animation
+        return [ctrl for ctrl in (primary,) if ctrl is not None]
+
+    def _get_active_controllers(self, controllers: List[object]) -> List[object]:
+        active = list(controllers)
+        if self.animation_controller is not None and self.animation_controller not in active:
+            active.append(self.animation_controller)
+        return active
 
     def _toggle_flag(self, controller: object, name: str, enabled: bool) -> None:
         if not hasattr(controller, name):
@@ -314,9 +318,12 @@ class BatteryMonitorCLI(Loggable):
             "direction": args.scroll_direction,
         }
 
-        controller = self.animation_controller
-        loop = controller is not None
-        if controller is not None:
+        primary = self.controllers[0]
+        secondary = self.animation_controller
+        controller = secondary or primary
+        loop = secondary is not None
+
+        if secondary:
             if charging == self.last_charging_state:
                 log.debug("Animation controller already showing state: %s", charging)
                 return

--- a/ismf_battery_monitor/scripts/battery_monitor/main.py
+++ b/ismf_battery_monitor/scripts/battery_monitor/main.py
@@ -1,11 +1,13 @@
-"""CLI entry point for the ISMF Battery Monitor."""
+"""
+CLI entry point for the ISMF Battery Monitor application.
+"""
 
 from __future__ import annotations
 
 import logging
-from threading import Thread
 import time
-from threading import Event
+from dataclasses import dataclass
+from threading import Event, Thread
 from typing import Dict, List, Optional, Sequence
 
 from easy_exit_calls import ExitCallHandler
@@ -19,15 +21,15 @@ from ...scenes import get_composite_scene_for_battery_level
 from .arguments import BatteryMonitorArgumentParser
 
 
-MOD_LOGGER = ROOT_LOGGER.get_child('ismf_battery_monitor.scripts.battery_monitor.main')
-MOD_LOGGER.set_level(console_level='debug')
+MOD_LOGGER = ROOT_LOGGER.get_child("ismf_battery_monitor.scripts.battery_monitor.main")
+MOD_LOGGER.set_level(console_level="debug")
 
 
 def _determine_log_level(args) -> int:
-    if getattr(args, 'quiet', False):
+    if getattr(args, "quiet", False):
         return logging.ERROR
 
-    verbosity = getattr(args, 'verbose', 0) or 0
+    verbosity = getattr(args, "verbose", 0) or 0
     if verbosity >= 2:
         return logging.DEBUG
     if verbosity == 1:
@@ -37,108 +39,172 @@ def _determine_log_level(args) -> int:
 
 def _configure_logging(args) -> logging.Logger:
     """Configure logging level and destination based on CLI args."""
-
     level = _determine_log_level(args)
 
-    logger = logging.getLogger('ismf_battery_monitor.cli')
+    logger = logging.getLogger("ismf_battery_monitor.cli")
     logger.setLevel(level)
     logger.handlers.clear()
+
     handler: logging.Handler
-    if args.log_file:
-        handler = logging.FileHandler(args.log_file, encoding='utf-8')
+    if getattr(args, "log_file", None):
+        handler = logging.FileHandler(args.log_file, encoding="utf-8")
     else:
         handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter('[%(asctime)s] %(levelname)s: %(message)s'))
+
+    handler.setFormatter(logging.Formatter("[%(asctime)s] %(levelname)s: %(message)s"))
     logger.addHandler(handler)
     logger.propagate = False
     return logger
 
 
+@dataclass(frozen=True)
+class ErrorDecision:
+    exit_code: int
+    user_message: str
+    log_message: str
+    can_retry: bool = False
+
+
+def _looks_like_no_matrix(exc: BaseException) -> bool:
+    msg = str(exc)
+    return (
+        "No LED matrix controllers detected" in msg
+        or BatteryMonitorCLI.NO_MATRIX_ERR in msg  # type: ignore[name-defined]
+    )
+
+
 class BatteryMonitorCLI(Loggable):
     """Encapsulates the CLI workflow for easier testing and maintenance."""
 
+    NO_MATRIX_ERR = "No LED matrix controllers detected."
+
     def __init__(self, args, *, logger: Optional[logging.Logger] = None):
         super().__init__(MOD_LOGGER)
-        self.args    = args
-        self.logger  = self.class_logger
+
+        self._threads: List[Thread] = []
+        self._cycles = 0
+
+        self.args = args
+        # Use injected logger if provided; otherwise fall back to the Loggable logger.
+        self.logger = logger or self.class_logger
+
         self.monitor = BatteryMonitor(poll_interval=args.poll_interval)
         self.stop_event = Event()
+
         self.controllers: List[object] = []
-        self.display_controller: Optional[object] = None
-        self.animation_controller: Optional[object] = None
-        self.animation_thread: Optional[Thread] = None
-        self.animation_charging_state: Optional[bool] = None
+        self.last_charging_state: Optional[bool] = None
+
         self.exit_handler = ExitCallHandler()
         self.exit_handler.register_handler(self._shutdown)
+
         self._monitor_started = False
         self._controller_states: Dict[object, Dict[str, object]] = {}
+
+    @property
+    def cycles(self) -> int:
+        return self._cycles
+
+    @property
+    def threads(self) -> List[Thread]:
+        return self._threads
+
+    @threads.deleter
+    def threads(self) -> None:
+        for thread in self._threads:
+            thread.join()
+        self._threads.clear()
+
+    # ------------------------------------------------------------------
+    # Error decisioning (centralized)
+    # ------------------------------------------------------------------
+    def _triage_error(self, exc: BaseException) -> ErrorDecision:
+        msg = str(exc)
+
+        if _looks_like_no_matrix(exc):
+            return ErrorDecision(
+                exit_code=1,
+                user_message="No LED matrix controllers detected. Is there at least one matrix module connected?",
+                log_message=msg,
+                can_retry=False,
+            )
+
+        # Keep your existing behavior: everything else exits 1 with a generic message.
+        return ErrorDecision(
+            exit_code=1,
+            user_message=f"An error occurred: {msg}",
+            log_message=msg,
+            can_retry=False,
+        )
 
     # ------------------------------------------------------------------
     # Lifecycle helpers
     # ------------------------------------------------------------------
     def _prepare_controllers(self) -> List[object]:
         log = self.method_logger
-        log.debug('Preparing controllers...')
+        log.debug("Preparing controllers...")
+
         cache = get_cached_controllers()
         controllers = cache.get()
-        log.debug('Controllers: %s', controllers)
-        if not controllers:
-            log.error('No LED matrix controllers detected.')
-            raise RuntimeError('No LED matrix controllers detected.')
+        log.debug("Controllers: %s", controllers)
 
-        log.debug('Filtering controllers...')
-        self.display_controller, self.animation_controller = self._select_controllers(controllers)
-        controllers = [ctrl for ctrl in {self.display_controller, self.animation_controller} if ctrl]
         if not controllers:
-            log.error('No LED matrix controllers matched the requested side selection.')
-            raise RuntimeError('No LED matrix controllers matched the requested side selection.')
+            log.error(self.NO_MATRIX_ERR)
+            raise RuntimeError(self.NO_MATRIX_ERR)
 
-        log.debug('Controllers (display/animation): %s / %s', self.display_controller, self.animation_controller)
+        log.debug("Filtering controllers...")
+        controllers = self._filter_controllers(controllers)
+        if not controllers:
+            log.error("No LED matrix controllers matched the requested side selection.")
+            raise RuntimeError("No LED matrix controllers matched the requested side selection.")
+
+        log.debug("Controllers after filtering: %s", controllers)
 
         for controller in controllers:
-            log.debug('Preparing controller: %s', controller)
-            if self.args.brightness is not None:
-                log.debug('Setting brightness to %s', self.args.brightness)
-                controller.set_brightness(self.args.brightness)
-            log.debug('Clearing controller: %s', controller)
-            controller.clear()
-            log.debug('Enabling keep_alive for controller: %s', controller)
-            self._toggle_flag(controller, 'keep_alive', True)
-            if self.args.breathing:
-                log.debug('Enabling breathing for controller: %s', controller)
-                self._toggle_flag(controller, 'breathing', True)
+            log.debug("Preparing controller: %s", controller)
 
-        log.debug('Controllers prepared: %s', controllers)
+            if self.args.brightness is not None:
+                log.debug("Setting brightness to %s", self.args.brightness)
+                controller.set_brightness(self.args.brightness)
+
+            log.debug("Clearing controller: %s", controller)
+            controller.clear()
+
+            log.debug("Enabling keep_alive for controller: %s", controller)
+            self._toggle_flag(controller, "keep_alive", True)
+
+            if getattr(self.args, "breathing", False):
+                log.debug("Enabling breathing for controller: %s", controller)
+                self._toggle_flag(controller, "breathing", True)
+
+        log.debug("Controllers prepared: %s", controllers)
         return controllers
 
-    def _select_controllers(self, controllers: List[object]) -> tuple[Optional[object], Optional[object]]:
-        display_ctrl = None
-        animation_ctrl = None
-
-        if getattr(self.args, 'left_only', False):
-            display_ctrl = find_leftmost(controllers)
-        elif getattr(self.args, 'right_only', False):
-            display_ctrl = find_rightmost(controllers)
+    def _filter_controllers(self, controllers: List[object]) -> List[object]:
+        if getattr(self.args, "left_only", False):
+            selected = [find_leftmost(controllers)]
+        elif getattr(self.args, "right_only", False) or not (
+            getattr(self.args, "left_only", False) or getattr(self.args, "right_only", False)
+        ):
+            selected = [find_rightmost(controllers)]
         else:
-            right = find_rightmost(controllers)
-            left = find_leftmost(controllers)
-            display_ctrl = right or left
-            if left is not None and left is not display_ctrl:
-                animation_ctrl = left
+            selected = controllers
 
-        return display_ctrl, animation_ctrl
+        return [ctrl for ctrl in selected if ctrl is not None]
 
-    def _toggle_flag(self, controller, name: str, enabled: bool) -> None:
+    def _toggle_flag(self, controller: object, name: str, enabled: bool) -> None:
         if not hasattr(controller, name):
             return
+
         state = self._controller_states.setdefault(controller, {})
         state.setdefault(name, getattr(controller, name))
+
         try:
             setattr(controller, name, enabled)
         except Exception as exc:  # pragma: no cover - hardware specific
-            self.logger.debug('Failed to toggle %s for %s: %s', name, controller, exc)
+            self.logger.debug("Failed to toggle %s for %s: %s", name, controller, exc)
 
     def _restore_controllers(self) -> None:
+        log = self.method_logger
         for controller, state in self._controller_states.items():
             for name, original in state.items():
                 if not hasattr(controller, name):
@@ -146,29 +212,39 @@ class BatteryMonitorCLI(Loggable):
                 try:
                     setattr(controller, name, original)
                 except Exception as exc:  # pragma: no cover - hardware specific
-                    self.logger.debug('Failed to restore %s for %s: %s', name, controller, exc)
+                    self.logger.debug("Failed to restore %s for %s: %s", name, controller, exc)
+
+            log.debug(f'Clearing matrix {id(controller)}/{controller.location}...')
+            controller.clear()
+
         self._controller_states.clear()
 
-    def _shutdown(self, *_):
+    def _shutdown(self, *_: object) -> None:
         if self.stop_event.is_set():
             return
 
         if self._monitor_started:
-            self.logger.info('Stopping battery monitor...')
+            self.logger.info("Stopping battery monitor...")
+
         self.stop_event.set()
-        if self.animation_thread and self.animation_thread.is_alive():
-            self.animation_thread.join(timeout=1.0)
+
         if self._monitor_started:
             self.monitor.stop()
+
         self._restore_controllers()
 
     def _wait_for_stop(self) -> None:
         log = self.method_logger
+        waits = 0
         try:
             while not self.stop_event.is_set():
-                log.debug('Waiting for stop...')
+                if waits >= 150:
+                    log.debug("Waiting for stop...")
+                    waits = 0
+                waits += 1
+                self._cycles += 1
                 time.sleep(0.2)
-        except KeyboardInterrupt:  # pragma: no cover - handled by signals typically
+        except KeyboardInterrupt:  # pragma: no cover
             self._shutdown()
 
     # ------------------------------------------------------------------
@@ -180,116 +256,143 @@ class BatteryMonitorCLI(Loggable):
             return
 
         pct = status.battery_percent
-        self.animation_charging_state = status.charging
-        self._draw_scene(pct)
+        self._draw_scene(pct, status.charging)
+        self._maybe_run_animation(status.charging)
         self._log_battery_level(pct)
+        self.last_charging_state = status.charging
 
     def _log_unavailable(self, status) -> None:
-        self.logger.debug('Battery percent unavailable in snapshot: %s', status)
+        self.logger.debug("Battery percent unavailable in snapshot: %s", status)
 
-    def _draw_scene(self, battery_percent: int) -> None:
+    def _draw_scene(self, battery_percent: int, charging_state: Optional[bool]) -> None:
         scene = get_composite_scene_for_battery_level(
             battery_percent,
             digits_on_bottom=self.args.digits_on_bottom,
             invert_on_overlap=self.args.invert_on_overlap,
-            charging_state=None,
-            show_charge_indicator=False,
+            charging_state=charging_state,
         )
 
-        if not self.display_controller:
-            return
-
-        _ = Thread(target=scene.draw, args=[self.display_controller])
-
-        try:
-            _.start()
-        except Exception as exc:  # pragma: no cover - hardware specific
-            self.logger.error('Failed to draw scene on controller %s: %s', self.display_controller, exc)
-
-    def _start_animation_loop(self) -> None:
-        if not (self.args.show_animations and self.animation_controller):
-            return
-
-        self.animation_thread = Thread(target=self._animation_loop, daemon=True)
-        try:
-            self.animation_thread.start()
-        except Exception as exc:  # pragma: no cover - hardware specific
-            self.logger.warning('Failed to start animation thread: %s', exc)
-
-    def _animation_loop(self) -> None:
-        assert self.animation_controller  # for type checkers
-        args = self.args
-        controller = self.animation_controller
-
-        while not self.stop_event.is_set():
-            charging = self.animation_charging_state
-            if charging is None:
-                time.sleep(0.2)
-                continue
-
-            animation_fn = play_batt_up_animation if charging else play_batt_down_animation
+        for controller in self.controllers:
+            t = Thread(target=scene.draw, args=(controller,))
             try:
-                animation_fn(
-                    controller,
-                    brightness=args.animation_brightness,
-                    frame_duration=args.frame_duration,
-                    direction=args.scroll_direction,
-                )
+                t.start()
+                # If you want to join these later, track them:
+                self.threads.append(t)
             except Exception as exc:  # pragma: no cover - hardware specific
-                self.logger.warning('Failed to run animation on %s: %s', controller, exc)
-                time.sleep(0.5)
-            finally:
-                if self.stop_event.is_set():
-                    break
+                self.logger.error("Failed to draw scene on controller %s: %s", controller, exc)
+
+    def _maybe_run_animation(self, charging: Optional[bool]) -> None:
+        log = self.method_logger
+
+        if not (
+            getattr(self.args, "show_animations", False)
+            and self.controllers
+            and self.last_charging_state is not None
+            and charging is not None
+            and charging != self.last_charging_state
+        ):
+            log.debug("Not running animation: %s", charging)
+            return
+
+        log.debug("Running animation: %s", charging)
+        animation_fn = play_batt_up_animation if charging else play_batt_down_animation
+
+        args = self.args
+        opts = {
+            "brightness": args.animation_brightness,
+            "frame_duration": args.frame_duration,
+            "direction": args.scroll_direction,
+        }
+
+        loop = False
+        if len(self.controllers) > 1:
+            log.debug("Found multiple controllers, running animation on leftmost")
+            loop = True
+            controller = find_leftmost(self.controllers)
+        else:
+            log.debug("Found single controller, running animation on it")
+            controller = self.controllers[0]
+
+        opts["loop"] = loop
+
+        t = Thread(target=animation_fn, args=(controller,), kwargs=opts)
+        try:
+            t.start()
+            self.threads.append(t)
+        except Exception as exc:  # pragma: no cover - hardware specific
+            log.warning("Failed to run animation on %s: %s", controller, exc)
 
     def _log_battery_level(self, battery_percent: int) -> None:
         if battery_percent <= self.args.critical_battery_threshold:
-            self.logger.warning('Battery critical: %s%%', battery_percent)
+            self.logger.warning("Battery critical: %s%%", battery_percent)
         elif battery_percent <= self.args.low_battery_threshold:
-            self.logger.info('Battery low: %s%%', battery_percent)
+            self.logger.info("Battery low: %s%%", battery_percent)
         else:
-            self.logger.debug('Battery status updated: %s%%', battery_percent)
+            self.logger.debug("Battery status updated: %s%%", battery_percent)
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
     def run(self) -> None:
+        log = self.method_logger
+
+        # Optional: if you later add an arg, this won’t crash without it.
+        max_attempts = 2 if getattr(self.args, "recover_once", False) else 1
+
         try:
-            self.controllers = self._prepare_controllers()
-            self._start_animation_loop()
-            self.logger.info('Starting battery monitor loop...')
-            self.monitor.start(self._handle_status)
-            self._monitor_started = True
-            self._wait_for_stop()
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    self.controllers = self._prepare_controllers()
+                    log.info("Starting battery monitor loop...")
+                    self.monitor.start(self._handle_status)
+                    self._monitor_started = True
+                    self._wait_for_stop()
+                    break
+                except Exception as exc:
+                    decision = self._triage_error(exc)
+                    log.error(f'Battery monitor loop failed: {decision.log_message}')
+
+                    if decision.can_retry and attempt < max_attempts:
+                        log.warning(f"Attempting recovery ({attempt}/{max_attempts})...")
+
+                        self._shutdown()
+                        # reset for next attempt
+                        self.stop_event.clear()
+                        self._monitor_started = False
+                        continue
+
+                    raise SystemExit(decision.exit_code) from exc
+
         finally:
-            self.exit_handler.unregister_handler(self._shutdown)
+            log.debug("Cleaning up exit handlers...")
+            if self.exit_handler.function_registered(self._shutdown):
+                log.debug("Unregistering found exit handler...")
+                self.exit_handler.unregister_handler(self._shutdown)
+            else:
+                log.debug("No exit handler found.")
             self._shutdown()
+
         if self._monitor_started:
-            self.logger.info('Battery monitor stopped.')
+            log.info("Battery monitor stopped.")
 
 
 def main(argv: Optional[Sequence[str]] = None) -> None:
     """Entrypoint for the ``ismf-battery-monitor`` console script."""
-
     parser = BatteryMonitorArgumentParser()
     args = parser.parse_args(argv)
     logger = _configure_logging(args)
 
-    if args.dry_run:
-        logger.info('Dry run: would start monitoring with poll interval %.2fs', args.poll_interval)
+    if getattr(args, "dry_run", False):
+        logger.info("Dry run: would start monitoring with poll interval %.2fs", args.poll_interval)
         return
 
     try:
         cli = BatteryMonitorCLI(args, logger=logger)
+        cli.run()
     except NotImplementedError as exc:  # pragma: no cover - platform specific
         logger.error(str(exc))
         raise SystemExit(1) from exc
 
-    try:
-        cli.run()
-    except RuntimeError as err:
-        parser.error(str(err))
 
-
-if __name__ == '__main__':  # pragma: no cover
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/ismf_battery_monitor/scripts/battery_monitor/main.py
+++ b/ismf_battery_monitor/scripts/battery_monitor/main.py
@@ -12,7 +12,7 @@ from easy_exit_calls import ExitCallHandler
 
 from is_matrix_forge.led_matrix.controller.helpers import find_leftmost, find_rightmost
 from ismf_battery_monitor.log_engine import ROOT_LOGGER, Loggable
-from ...animations import plugged_in, unplugged
+from ...animations import play_batt_down_animation, play_batt_up_animation
 from ...controllers import get_cached_controllers
 from ...monitor import BatteryMonitor
 from ...scenes import get_composite_scene_for_battery_level
@@ -64,7 +64,7 @@ class BatteryMonitorCLI(Loggable):
         self.monitor = BatteryMonitor(poll_interval=args.poll_interval)
         self.stop_event = Event()
         self.controllers: List[object] = []
-        self.last_plugged_state: Optional[bool] = None
+        self.last_charging_state: Optional[bool] = None
         self.exit_handler = ExitCallHandler()
         self.exit_handler.register_handler(self._shutdown)
         self._monitor_started = False
@@ -110,7 +110,10 @@ class BatteryMonitorCLI(Loggable):
     def _filter_controllers(self, controllers: List[object]) -> List[object]:
         if getattr(self.args, 'left_only', False):
             selected = [find_leftmost(controllers)]
-        elif getattr(self.args, 'right_only', False):
+        elif getattr(self.args, 'right_only', False) or not (
+            getattr(self.args, 'left_only', False)
+            or getattr(self.args, 'right_only', False)
+        ):
             selected = [find_rightmost(controllers)]
         else:
             selected = controllers
@@ -150,10 +153,8 @@ class BatteryMonitorCLI(Loggable):
 
     def _wait_for_stop(self) -> None:
         log = self.method_logger
-        attempts = 0
         try:
             while not self.stop_event.is_set():
-                if
                 log.debug('Waiting for stop...')
                 time.sleep(0.2)
         except KeyboardInterrupt:  # pragma: no cover - handled by signals typically
@@ -169,9 +170,9 @@ class BatteryMonitorCLI(Loggable):
 
         pct = status.battery_percent
         self._draw_scene(pct, status.charging)
-        self._maybe_run_animation(status.ac_online)
+        self._maybe_run_animation(status.charging)
         self._log_battery_level(pct)
-        self.last_plugged_state = status.ac_online
+        self.last_charging_state = status.charging
 
     def _log_unavailable(self, status) -> None:
         self.logger.debug('Battery percent unavailable in snapshot: %s', status)
@@ -192,17 +193,17 @@ class BatteryMonitorCLI(Loggable):
             except Exception as exc:  # pragma: no cover - hardware specific
                 self.logger.error('Failed to draw scene on controller %s: %s', controller, exc)
 
-    def _maybe_run_animation(self, ac_online: Optional[bool]) -> None:
+    def _maybe_run_animation(self, charging: Optional[bool]) -> None:
         if not (
             self.args.show_animations
             and self.controllers
-            and self.last_plugged_state is not None
-            and ac_online is not None
-            and ac_online != self.last_plugged_state
+            and self.last_charging_state is not None
+            and charging is not None
+            and charging != self.last_charging_state
         ):
             return
 
-        animation_fn = plugged_in if ac_online else unplugged
+        animation_fn = play_batt_up_animation if charging else play_batt_down_animation
         args = self.args
         opts = {
             'brightness':     args.animation_brightness,

--- a/ismf_battery_monitor/scripts/battery_monitor/main.py
+++ b/ismf_battery_monitor/scripts/battery_monitor/main.py
@@ -92,7 +92,6 @@ class BatteryMonitorCLI(Loggable):
         self.stop_event = Event()
 
         self.controllers: List[object] = []
-        self.animation_controller: Optional[object] = None
         self.last_charging_state: Optional[bool] = None
 
         self.exit_handler = ExitCallHandler()
@@ -160,9 +159,7 @@ class BatteryMonitorCLI(Loggable):
 
         log.debug("Controllers after filtering: %s", controllers)
 
-        controllers_to_prepare = self._get_active_controllers(controllers)
-
-        for controller in controllers_to_prepare:
+        for controller in controllers:
             log.debug("Preparing controller: %s", controller)
 
             if self.args.brightness is not None:
@@ -179,33 +176,25 @@ class BatteryMonitorCLI(Loggable):
                 log.debug("Enabling breathing for controller: %s", controller)
                 self._toggle_flag(controller, "breathing", True)
 
-        log.debug("Controllers prepared: %s", controllers_to_prepare)
+        log.debug("Controllers prepared: %s", controllers)
         return controllers
 
     def _filter_controllers(self, controllers: List[object]) -> List[object]:
         left = find_leftmost(controllers)
         right = find_rightmost(controllers)
 
-        primary = None
-        animation = None
-
         if getattr(self.args, "left_only", False):
-            primary = left
+            selected = [left]
         elif getattr(self.args, "right_only", False):
-            primary = right
+            selected = [right]
         else:
             primary = right or left
+            secondary = None
             if left is not None and right is not None and left is not right:
-                animation = left if primary is right else right
+                secondary = left if primary is right else right
+            selected = [primary, secondary]
 
-        self.animation_controller = animation
-        return [ctrl for ctrl in (primary,) if ctrl is not None]
-
-    def _get_active_controllers(self, controllers: List[object]) -> List[object]:
-        active = list(controllers)
-        if self.animation_controller is not None and self.animation_controller not in active:
-            active.append(self.animation_controller)
-        return active
+        return [ctrl for ctrl in selected if ctrl is not None]
 
     def _toggle_flag(self, controller: object, name: str, enabled: bool) -> None:
         if not hasattr(controller, name):
@@ -308,6 +297,22 @@ class BatteryMonitorCLI(Loggable):
             log.debug("Not running animation: %s", charging)
             return
 
+        has_secondary = len(self.controllers) > 1
+        last = self.last_charging_state
+        if has_secondary:
+            should_animate = charging != last
+        else:
+            should_animate = last is not None and charging != last
+
+        if not should_animate:
+            log.debug(
+                "Not running animation (%s controller rule), state: %s → %s",
+                "secondary" if has_secondary else "primary",
+                last,
+                charging,
+            )
+            return
+
         log.debug("Running animation: %s", charging)
         animation_fn = play_batt_up_animation if charging else play_batt_down_animation
 
@@ -316,26 +321,17 @@ class BatteryMonitorCLI(Loggable):
             "brightness": args.animation_brightness,
             "frame_duration": args.frame_duration,
             "direction": args.scroll_direction,
+            "loop": has_secondary,
         }
 
-        primary = self.controllers[0]
-        secondary = self.animation_controller
-        controller = secondary or primary
-        loop = secondary is not None
-
-        if secondary:
-            if charging == self.last_charging_state:
-                log.debug("Animation controller already showing state: %s", charging)
-                return
-            log.debug("Found secondary controller, running animation on it")
-        else:
-            if self.last_charging_state is None or charging == self.last_charging_state:
-                log.debug("Not running animation on primary controller")
-                return
-            log.debug("Found single controller, running animation on it")
-            controller = self.controllers[0]
-
-        opts["loop"] = loop
+        controller = self.controllers[1] if has_secondary else self.controllers[0]
+        log.debug(
+            "Running animation on %s controller: %s, charging=%s, loop=%s",
+            "secondary" if has_secondary else "primary",
+            controller,
+            charging,
+            opts["loop"],
+        )
 
         t = Thread(target=animation_fn, args=(controller,), kwargs=opts)
         try:

--- a/ismf_battery_monitor/scripts/battery_monitor/main.py
+++ b/ismf_battery_monitor/scripts/battery_monitor/main.py
@@ -64,7 +64,10 @@ class BatteryMonitorCLI(Loggable):
         self.monitor = BatteryMonitor(poll_interval=args.poll_interval)
         self.stop_event = Event()
         self.controllers: List[object] = []
-        self.last_charging_state: Optional[bool] = None
+        self.display_controller: Optional[object] = None
+        self.animation_controller: Optional[object] = None
+        self.animation_thread: Optional[Thread] = None
+        self.animation_charging_state: Optional[bool] = None
         self.exit_handler = ExitCallHandler()
         self.exit_handler.register_handler(self._shutdown)
         self._monitor_started = False
@@ -84,12 +87,13 @@ class BatteryMonitorCLI(Loggable):
             raise RuntimeError('No LED matrix controllers detected.')
 
         log.debug('Filtering controllers...')
-        controllers = self._filter_controllers(controllers)
+        self.display_controller, self.animation_controller = self._select_controllers(controllers)
+        controllers = [ctrl for ctrl in {self.display_controller, self.animation_controller} if ctrl]
         if not controllers:
             log.error('No LED matrix controllers matched the requested side selection.')
             raise RuntimeError('No LED matrix controllers matched the requested side selection.')
 
-        log.debug('Controllers: %s', controllers)
+        log.debug('Controllers (display/animation): %s / %s', self.display_controller, self.animation_controller)
 
         for controller in controllers:
             log.debug('Preparing controller: %s', controller)
@@ -107,17 +111,22 @@ class BatteryMonitorCLI(Loggable):
         log.debug('Controllers prepared: %s', controllers)
         return controllers
 
-    def _filter_controllers(self, controllers: List[object]) -> List[object]:
+    def _select_controllers(self, controllers: List[object]) -> tuple[Optional[object], Optional[object]]:
+        display_ctrl = None
+        animation_ctrl = None
+
         if getattr(self.args, 'left_only', False):
-            selected = [find_leftmost(controllers)]
-        elif getattr(self.args, 'right_only', False) or not (
-            getattr(self.args, 'left_only', False)
-            or getattr(self.args, 'right_only', False)
-        ):
-            selected = [find_rightmost(controllers)]
+            display_ctrl = find_leftmost(controllers)
+        elif getattr(self.args, 'right_only', False):
+            display_ctrl = find_rightmost(controllers)
         else:
-            selected = controllers
-        return [ctrl for ctrl in selected if ctrl is not None]
+            right = find_rightmost(controllers)
+            left = find_leftmost(controllers)
+            display_ctrl = right or left
+            if left is not None and left is not display_ctrl:
+                animation_ctrl = left
+
+        return display_ctrl, animation_ctrl
 
     def _toggle_flag(self, controller, name: str, enabled: bool) -> None:
         if not hasattr(controller, name):
@@ -147,6 +156,8 @@ class BatteryMonitorCLI(Loggable):
         if self._monitor_started:
             self.logger.info('Stopping battery monitor...')
         self.stop_event.set()
+        if self.animation_thread and self.animation_thread.is_alive():
+            self.animation_thread.join(timeout=1.0)
         if self._monitor_started:
             self.monitor.stop()
         self._restore_controllers()
@@ -169,55 +180,67 @@ class BatteryMonitorCLI(Loggable):
             return
 
         pct = status.battery_percent
-        self._draw_scene(pct, status.charging)
-        self._maybe_run_animation(status.charging)
+        self.animation_charging_state = status.charging
+        self._draw_scene(pct)
         self._log_battery_level(pct)
-        self.last_charging_state = status.charging
 
     def _log_unavailable(self, status) -> None:
         self.logger.debug('Battery percent unavailable in snapshot: %s', status)
 
-    def _draw_scene(self, battery_percent: int, charging_state: Optional[bool]) -> None:
+    def _draw_scene(self, battery_percent: int) -> None:
         scene = get_composite_scene_for_battery_level(
             battery_percent,
             digits_on_bottom=self.args.digits_on_bottom,
             invert_on_overlap=self.args.invert_on_overlap,
-            charging_state=charging_state
+            charging_state=None,
+            show_charge_indicator=False,
         )
 
-        for controller in self.controllers:
-            _ = Thread(target=scene.draw, args=[controller])
-
-            try:
-                _.start()
-            except Exception as exc:  # pragma: no cover - hardware specific
-                self.logger.error('Failed to draw scene on controller %s: %s', controller, exc)
-
-    def _maybe_run_animation(self, charging: Optional[bool]) -> None:
-        if not (
-            self.args.show_animations
-            and self.controllers
-            and self.last_charging_state is not None
-            and charging is not None
-            and charging != self.last_charging_state
-        ):
+        if not self.display_controller:
             return
 
-        animation_fn = play_batt_up_animation if charging else play_batt_down_animation
+        _ = Thread(target=scene.draw, args=[self.display_controller])
+
+        try:
+            _.start()
+        except Exception as exc:  # pragma: no cover - hardware specific
+            self.logger.error('Failed to draw scene on controller %s: %s', self.display_controller, exc)
+
+    def _start_animation_loop(self) -> None:
+        if not (self.args.show_animations and self.animation_controller):
+            return
+
+        self.animation_thread = Thread(target=self._animation_loop, daemon=True)
+        try:
+            self.animation_thread.start()
+        except Exception as exc:  # pragma: no cover - hardware specific
+            self.logger.warning('Failed to start animation thread: %s', exc)
+
+    def _animation_loop(self) -> None:
+        assert self.animation_controller  # for type checkers
         args = self.args
-        opts = {
-            'brightness':     args.animation_brightness,
-            'frame_duration': args.frame_duration,
-            'direction':      args.scroll_direction,
-        }
-        threads = []
-        for controller in self.controllers:
-            _ = Thread(target=animation_fn, args=[controller], kwargs=opts)
+        controller = self.animation_controller
+
+        while not self.stop_event.is_set():
+            charging = self.animation_charging_state
+            if charging is None:
+                time.sleep(0.2)
+                continue
+
+            animation_fn = play_batt_up_animation if charging else play_batt_down_animation
             try:
-                _.start()
-                threads.append(_)
+                animation_fn(
+                    controller,
+                    brightness=args.animation_brightness,
+                    frame_duration=args.frame_duration,
+                    direction=args.scroll_direction,
+                )
             except Exception as exc:  # pragma: no cover - hardware specific
                 self.logger.warning('Failed to run animation on %s: %s', controller, exc)
+                time.sleep(0.5)
+            finally:
+                if self.stop_event.is_set():
+                    break
 
     def _log_battery_level(self, battery_percent: int) -> None:
         if battery_percent <= self.args.critical_battery_threshold:
@@ -233,6 +256,7 @@ class BatteryMonitorCLI(Loggable):
     def run(self) -> None:
         try:
             self.controllers = self._prepare_controllers()
+            self._start_animation_loop()
             self.logger.info('Starting battery monitor loop...')
             self.monitor.start(self._handle_status)
             self._monitor_started = True

--- a/tests/test_battery_monitor_cli.py
+++ b/tests/test_battery_monitor_cli.py
@@ -1,9 +1,22 @@
 from argparse import Namespace
 import importlib
+import threading
 
 import pytest
 
 cli_main = importlib.import_module('ismf_battery_monitor.scripts.battery_monitor.main')
+
+
+class DummyController:
+    def __init__(self, name):
+        self.name = name
+        self._thread_safe = True
+
+    def clear(self):
+        return None
+
+    def __repr__(self):  # pragma: no cover - helps with assertion diffs
+        return f'<DummyController {self.name}>'
 
 
 class DummyMonitor:
@@ -43,51 +56,83 @@ def _mock_monitor(monkeypatch):
     monkeypatch.setattr(cli_main, 'BatteryMonitor', DummyMonitor)
 
 
-def test_defaults_select_right_matrix(monkeypatch):
-    args = _build_args(left_only=False, right_only=False)
-    cli = cli_main.BatteryMonitorCLI(args)
+def _mock_controller_cache(monkeypatch, controllers):
+    class DummyCache:
+        def get(self):
+            return controllers
 
-    controllers = ['left', 'right']
+    monkeypatch.setattr(cli_main, 'get_cached_controllers', lambda: DummyCache())
+
+
+def test_defaults_use_right_for_display_and_left_for_animation(monkeypatch):
+    left = DummyController('left')
+    right = DummyController('right')
+    _mock_controller_cache(monkeypatch, [left, right])
     monkeypatch.setattr(cli_main, 'find_leftmost', lambda ctrls: ctrls[0])
-    monkeypatch.setattr(cli_main, 'find_rightmost', lambda ctrls: ctrls[-1])
+    monkeypatch.setattr(cli_main, 'find_rightmost', lambda ctrls: ctrls[1])
 
-    assert cli._filter_controllers(controllers) == ['right']
-
-
-def test_batt_up_and_down_animations_based_on_charging(monkeypatch):
     args = _build_args()
     cli = cli_main.BatteryMonitorCLI(args)
-    cli.controllers = ['right']
-    cli.last_charging_state = False
+
+    controllers = cli._prepare_controllers()
+
+    assert cli.display_controller is right
+    assert cli.animation_controller is left
+    assert set(controllers) == {left, right}
+
+
+def test_draw_scene_omits_charge_indicator(monkeypatch):
+    args = _build_args()
+    cli = cli_main.BatteryMonitorCLI(args)
+    cli.display_controller = DummyController('display')
+
+    captured = {}
+
+    def fake_scene_factory(battery_percent, *, charging_state, show_charge_indicator, **_):
+        captured['charging_state'] = charging_state
+        captured['show_charge_indicator'] = show_charge_indicator
+        captured['battery_percent'] = battery_percent
+
+        class DummyScene:
+            def draw(self, controller):
+                captured['controller'] = controller
+
+        return DummyScene()
+
+    monkeypatch.setattr(cli_main, 'get_composite_scene_for_battery_level', fake_scene_factory)
+
+    cli._draw_scene(42)
+
+    assert captured == {
+        'battery_percent': 42,
+        'charging_state': None,
+        'show_charge_indicator': False,
+        'controller': cli.display_controller,
+    }
+
+
+def test_animation_loop_runs_on_left_matrix(monkeypatch):
+    left = DummyController('left')
+    args = _build_args()
+    cli = cli_main.BatteryMonitorCLI(args)
+    cli.animation_controller = left
+    cli.animation_charging_state = True
 
     calls = []
 
     def fake_up(controller, **kwargs):
         calls.append(('up', controller, kwargs))
-
-    def fake_down(controller, **kwargs):
-        calls.append(('down', controller, kwargs))
+        cli.stop_event.set()
 
     monkeypatch.setattr(cli_main, 'play_batt_up_animation', fake_up)
-    monkeypatch.setattr(cli_main, 'play_batt_down_animation', fake_down)
+    monkeypatch.setattr(cli_main, 'play_batt_down_animation', lambda *_, **__: None)
 
-    cli._maybe_run_animation(True)
-    assert calls == [('up', 'right', {
+    thread = threading.Thread(target=cli._animation_loop)
+    thread.start()
+    thread.join(timeout=2)
+
+    assert calls == [('up', left, {
         'brightness': args.animation_brightness,
         'frame_duration': args.frame_duration,
         'direction': args.scroll_direction,
     })]
-
-    calls.clear()
-    cli.last_charging_state = True
-    cli._maybe_run_animation(False)
-    assert calls == [('down', 'right', {
-        'brightness': args.animation_brightness,
-        'frame_duration': args.frame_duration,
-        'direction': args.scroll_direction,
-    })]
-
-    calls.clear()
-    cli.last_charging_state = False
-    cli._maybe_run_animation(False)
-    assert calls == []

--- a/tests/test_battery_monitor_cli.py
+++ b/tests/test_battery_monitor_cli.py
@@ -1,0 +1,93 @@
+from argparse import Namespace
+import importlib
+
+import pytest
+
+cli_main = importlib.import_module('ismf_battery_monitor.scripts.battery_monitor.main')
+
+
+class DummyMonitor:
+    def __init__(self, poll_interval):
+        self.poll_interval = poll_interval
+
+    def start(self, *_):
+        return None
+
+    def stop(self):
+        return None
+
+
+def _build_args(**overrides):
+    defaults = dict(
+        poll_interval=1.0,
+        brightness=None,
+        breathing=False,
+        digits_on_bottom=None,
+        invert_on_overlap=True,
+        left_only=False,
+        right_only=False,
+        show_animations=True,
+        animation_brightness=50,
+        frame_duration=0.5,
+        scroll_direction='vertical_up',
+        low_battery_threshold=20,
+        critical_battery_threshold=10,
+        log_file=None,
+    )
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+@pytest.fixture(autouse=True)
+def _mock_monitor(monkeypatch):
+    monkeypatch.setattr(cli_main, 'BatteryMonitor', DummyMonitor)
+
+
+def test_defaults_select_right_matrix(monkeypatch):
+    args = _build_args(left_only=False, right_only=False)
+    cli = cli_main.BatteryMonitorCLI(args)
+
+    controllers = ['left', 'right']
+    monkeypatch.setattr(cli_main, 'find_leftmost', lambda ctrls: ctrls[0])
+    monkeypatch.setattr(cli_main, 'find_rightmost', lambda ctrls: ctrls[-1])
+
+    assert cli._filter_controllers(controllers) == ['right']
+
+
+def test_batt_up_and_down_animations_based_on_charging(monkeypatch):
+    args = _build_args()
+    cli = cli_main.BatteryMonitorCLI(args)
+    cli.controllers = ['right']
+    cli.last_charging_state = False
+
+    calls = []
+
+    def fake_up(controller, **kwargs):
+        calls.append(('up', controller, kwargs))
+
+    def fake_down(controller, **kwargs):
+        calls.append(('down', controller, kwargs))
+
+    monkeypatch.setattr(cli_main, 'play_batt_up_animation', fake_up)
+    monkeypatch.setattr(cli_main, 'play_batt_down_animation', fake_down)
+
+    cli._maybe_run_animation(True)
+    assert calls == [('up', 'right', {
+        'brightness': args.animation_brightness,
+        'frame_duration': args.frame_duration,
+        'direction': args.scroll_direction,
+    })]
+
+    calls.clear()
+    cli.last_charging_state = True
+    cli._maybe_run_animation(False)
+    assert calls == [('down', 'right', {
+        'brightness': args.animation_brightness,
+        'frame_duration': args.frame_duration,
+        'direction': args.scroll_direction,
+    })]
+
+    calls.clear()
+    cli.last_charging_state = False
+    cli._maybe_run_animation(False)
+    assert calls == []


### PR DESCRIPTION
## Summary
- default the battery-monitor CLI to render on the right-most LED matrix when no side flag is provided
- trigger batt_up/batt_down animations whenever the charging state changes
- add regression tests covering controller selection and charging animation behavior

## Testing
- PYTHONPATH=. pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924d6277050832da3bf3b18a923e674)

## Summary by Sourcery

Update battery monitor CLI behavior to default to the right-most LED matrix and to play directional charging animations when the charging state changes.

New Features:
- Add dedicated batt_up and batt_down charging direction animations and integrate them into the CLI charging state transitions.

Enhancements:
- Change controller selection so that when no side is specified, the CLI selects the right-most LED matrix by default instead of all matrices.
- Refine charging state tracking in the CLI to base animations on charging status rather than AC power presence.

Tests:
- Add CLI tests to verify default right-matrix selection and charging state–driven batt_up/batt_down animation behavior.