### PR TITLE
Avoid secondary redraw during animations and fix Windows logging arrow

### DIFF
--- a/ismf_battery_monitor/scripts/battery_monitor/main.py
+++ b/ismf_battery_monitor/scripts/battery_monitor/main.py
@@ -278,8 +278,8 @@ class BatteryMonitorCLI(Loggable):
         )
 
         controllers = self.controllers
-        if getattr(self.args, "show_animations", False) and len(self.controllers) > 1:
-            controllers = [self.controllers[0]]
+        if getattr(self.args, "show_animations", False) and len(controllers) > 1:
+            controllers = [controllers[0]]
 
         for controller in controllers:
             t = Thread(target=scene.draw, args=(controller,))

--- a/ismf_battery_monitor/scripts/battery_monitor/main.py
+++ b/ismf_battery_monitor/scripts/battery_monitor/main.py
@@ -277,7 +277,11 @@ class BatteryMonitorCLI(Loggable):
             charging_state=charging_state,
         )
 
-        for controller in self.controllers:
+        controllers = self.controllers
+        if getattr(self.args, "show_animations", False) and len(self.controllers) > 1:
+            controllers = [self.controllers[0]]
+
+        for controller in controllers:
             t = Thread(target=scene.draw, args=(controller,))
             try:
                 t.start()
@@ -306,7 +310,7 @@ class BatteryMonitorCLI(Loggable):
 
         if not should_animate:
             log.debug(
-                "Not running animation (%s controller rule), state: %s → %s",
+                "Not running animation (%s controller rule), state: %s -> %s",
                 "secondary" if has_secondary else "primary",
                 last,
                 charging,


### PR DESCRIPTION
### Motivation
- Prevent visual glitches where the secondary LED matrix briefly shows the progress scene while an animation runs. 
- Avoid choppy/stopping charging animations caused by concurrent redraws on both controllers. 
- Stop Unicode logging characters from raising encoding errors in Windows console environments. 

### Description
- When `show_animations` is enabled and more than one controller is present, `_draw_scene` now only draws to the primary controller to avoid redundant redraws on the secondary. 
- Replaced the Unicode arrow (`→`) in a debug message with an ASCII arrow (`->`) to prevent `UnicodeEncodeError` on Windows consoles. 
- Preserved existing threading behavior by still starting scene draw threads and appending them to `self.threads`. 

### Testing
- No automated tests were run because the changes are hardware-dependent and affect runtime behavior with physical LED controllers. 
- Existing test suite was not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d443949f4832da6ba4032ec68d5af)

## Summary by Sourcery

Limit animation drawing to the primary controller when animations are enabled with multiple controllers and adjust logging output for better Windows compatibility.

Bug Fixes:
- Prevent secondary controllers from being redundantly redrawn during animations when multiple controllers are present, avoiding visual glitches and choppy behavior.
- Replace a Unicode arrow in debug logging with an ASCII arrow to prevent potential encoding issues on Windows consoles.