### PR TITLE
Serialize secondary battery animations and add stoppable loop with shutdown cleanup

### DIFF
--- a/ismf_battery_monitor/animations.py
+++ b/ismf_battery_monitor/animations.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from importlib import resources
-from threading import Event
+from threading import Event, Thread
 
 from easy_exit_calls import ExitCallHandler
 from is_matrix_forge.led_matrix.controller.helpers import find_leftmost, find_rightmost
@@ -185,14 +185,17 @@ def play_batt_direction_loop(
     try:
         # Start the animation in loop mode
         # We'll monitor stop_event and call ani.stop() when needed
-        from threading import Thread as MonitorThread
         
         def monitor_stop():
             """Monitor the stop_event and stop the animation when signaled."""
             stop_event.wait()
-            ani.stop()
+            try:
+                ani.stop()
+            except Exception:
+                # Suppress exceptions in daemon thread to ensure cleanup proceeds
+                pass
         
-        monitor_thread = MonitorThread(target=monitor_stop, daemon=True)
+        monitor_thread = Thread(target=monitor_stop, daemon=True)
         monitor_thread.start()
         
         # Play the animation (this blocks until ani.stop() is called)

--- a/ismf_battery_monitor/animations.py
+++ b/ismf_battery_monitor/animations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from importlib import resources
+from threading import Event
 
 from easy_exit_calls import ExitCallHandler
 from is_matrix_forge.led_matrix.controller.helpers import find_leftmost, find_rightmost
@@ -148,6 +149,32 @@ def play_batt_down_animation(controller, *, brightness: int | None = None,
         frame_duration=frame_duration,
         loop=loop
     )
+
+
+def play_batt_direction_loop(
+    controller,
+    *,
+    charging: bool,
+    stop_event: Event,
+    brightness: int | None = None,
+    frame_duration: float = 1.0,
+) -> None:
+    ensure_thread_safety(controller)
+    prev_brightness = getattr(controller, 'brightness', None)
+    if brightness is not None:
+        controller.set_brightness(brightness)
+
+    try:
+        while not stop_event.is_set():
+            controller.clear()
+            filename = 'batt_up.json' if charging else 'batt_down.json'
+            ani = _load_animation_from_package(filename)
+            ani.set_all_frame_durations(frame_duration)
+            ani.loop = False
+            ani.play(controller)
+    finally:
+        if prev_brightness is not None:
+            controller.set_brightness(prev_brightness)
 
 
 def drain_progress(

--- a/ismf_battery_monitor/animations.py
+++ b/ismf_battery_monitor/animations.py
@@ -162,10 +162,8 @@ def play_batt_direction_loop(
     """
     Play battery charging/discharging animation in a stoppable loop.
     
-    Note: The stop_event is only checked between animation iterations, not during
-    playback itself. This means the thread cannot respond to stop requests until
-    the current animation completes, which may delay shutdown by up to one full
-    animation cycle.
+    The animation can be stopped mid-playback by setting the stop_event, which will
+    call Animation.stop() to interrupt the current animation immediately.
     
     Args:
         controller: The LED matrix controller to animate
@@ -182,13 +180,27 @@ def play_batt_direction_loop(
     filename = 'batt_up.json' if charging else 'batt_down.json'
     ani = _load_animation_from_package(filename)
     ani.set_all_frame_durations(frame_duration)
-    ani.loop = False
+    ani.loop = True  # Let the animation loop itself
 
     try:
-        while not stop_event.is_set():
-            controller.clear()
-            ani.play(controller)
+        # Start the animation in loop mode
+        # We'll monitor stop_event and call ani.stop() when needed
+        from threading import Thread as MonitorThread
+        
+        def monitor_stop():
+            """Monitor the stop_event and stop the animation when signaled."""
+            stop_event.wait()
+            ani.stop()
+        
+        monitor_thread = MonitorThread(target=monitor_stop, daemon=True)
+        monitor_thread.start()
+        
+        # Play the animation (this blocks until ani.stop() is called)
+        controller.clear()
+        ani.play(controller)
     finally:
+        # Ensure animation is stopped
+        ani.stop()
         if prev_brightness is not None:
             controller.set_brightness(prev_brightness)
         controller.clear()

--- a/ismf_battery_monitor/animations.py
+++ b/ismf_battery_monitor/animations.py
@@ -164,13 +164,14 @@ def play_batt_direction_loop(
     if brightness is not None:
         controller.set_brightness(brightness)
 
+    filename = 'batt_up.json' if charging else 'batt_down.json'
+    ani = _load_animation_from_package(filename)
+    ani.set_all_frame_durations(frame_duration)
+    ani.loop = False
+
     try:
         while not stop_event.is_set():
             controller.clear()
-            filename = 'batt_up.json' if charging else 'batt_down.json'
-            ani = _load_animation_from_package(filename)
-            ani.set_all_frame_durations(frame_duration)
-            ani.loop = False
             ani.play(controller)
     finally:
         if prev_brightness is not None:

--- a/ismf_battery_monitor/animations.py
+++ b/ismf_battery_monitor/animations.py
@@ -176,6 +176,7 @@ def play_batt_direction_loop(
     finally:
         if prev_brightness is not None:
             controller.set_brightness(prev_brightness)
+        controller.clear()
 
 
 def drain_progress(

--- a/ismf_battery_monitor/animations.py
+++ b/ismf_battery_monitor/animations.py
@@ -159,6 +159,21 @@ def play_batt_direction_loop(
     brightness: int | None = None,
     frame_duration: float = 1.0,
 ) -> None:
+    """
+    Play battery charging/discharging animation in a stoppable loop.
+    
+    Note: The stop_event is only checked between animation iterations, not during
+    playback itself. This means the thread cannot respond to stop requests until
+    the current animation completes, which may delay shutdown by up to one full
+    animation cycle.
+    
+    Args:
+        controller: The LED matrix controller to animate
+        charging: True for charging animation, False for discharging
+        stop_event: Event to signal the loop to stop
+        brightness: Optional brightness level for the animation
+        frame_duration: Duration of each animation frame in seconds
+    """
     ensure_thread_safety(controller)
     prev_brightness = getattr(controller, 'brightness', None)
     if brightness is not None:

--- a/ismf_battery_monitor/scripts/battery_monitor/main.py
+++ b/ismf_battery_monitor/scripts/battery_monitor/main.py
@@ -268,6 +268,10 @@ class BatteryMonitorCLI(Loggable):
         self._animation_stop = None
         self._animation_state = None
 
+    def _cleanup_finished_threads(self) -> None:
+        """Remove finished threads from the thread list to prevent memory leak."""
+        self._threads = [t for t in self._threads if t.is_alive()]
+
     def _wait_for_stop(self) -> None:
         log = self.method_logger
         waits = 0
@@ -323,6 +327,9 @@ class BatteryMonitorCLI(Loggable):
     def _maybe_run_animation(self, charging: Optional[bool]) -> None:
         log = self.method_logger
 
+        # Clean up finished threads periodically to prevent memory leak
+        self._cleanup_finished_threads()
+
         if not (
             getattr(self.args, "show_animations", False)
             and self.controllers
@@ -335,6 +342,9 @@ class BatteryMonitorCLI(Loggable):
         has_secondary = len(self.controllers) > 1
         last = self.last_charging_state
         if has_secondary:
+            # Note: The logic below relies on the check at line ~329 ensuring
+            # charging is not None. If refactored, ensure state comparison
+            # doesn't inadvertently match None == None on first call.
             if self._animation_thread and self._animation_thread.is_alive():
                 if self._animation_state == charging:
                     log.debug("Animation already running on secondary: %s", charging)

--- a/ismf_battery_monitor/scripts/battery_monitor/main.py
+++ b/ismf_battery_monitor/scripts/battery_monitor/main.py
@@ -14,7 +14,11 @@ from easy_exit_calls import ExitCallHandler
 
 from is_matrix_forge.led_matrix.controller.helpers import find_leftmost, find_rightmost
 from ismf_battery_monitor.log_engine import ROOT_LOGGER, Loggable
-from ...animations import play_batt_down_animation, play_batt_up_animation
+from ...animations import (
+    play_batt_direction_loop,
+    play_batt_down_animation,
+    play_batt_up_animation,
+)
 from ...controllers import get_cached_controllers
 from ...monitor import BatteryMonitor
 from ...scenes import get_composite_scene_for_battery_level
@@ -93,6 +97,9 @@ class BatteryMonitorCLI(Loggable):
 
         self.controllers: List[object] = []
         self.last_charging_state: Optional[bool] = None
+        self._animation_thread: Optional[Thread] = None
+        self._animation_stop: Optional[Event] = None
+        self._animation_state: Optional[bool] = None
 
         self.exit_handler = ExitCallHandler()
         self.exit_handler.register_handler(self._shutdown)
@@ -236,7 +243,18 @@ class BatteryMonitorCLI(Loggable):
         if self._monitor_started:
             self.monitor.stop()
 
+        self._stop_animation_thread()
         self._restore_controllers()
+
+    def _stop_animation_thread(self) -> None:
+        if self._animation_thread and self._animation_thread.is_alive():
+            if self._animation_stop is not None:
+                self._animation_stop.set()
+            self._animation_thread.join(timeout=2)
+
+        self._animation_thread = None
+        self._animation_stop = None
+        self._animation_state = None
 
     def _wait_for_stop(self) -> None:
         log = self.method_logger
@@ -277,7 +295,11 @@ class BatteryMonitorCLI(Loggable):
             charging_state=charging_state,
         )
 
-        for controller in self.controllers:
+        controllers = self.controllers
+        if getattr(self.args, "show_animations", False) and len(self.controllers) > 1:
+            controllers = [self.controllers[0]]
+
+        for controller in controllers:
             t = Thread(target=scene.draw, args=(controller,))
             try:
                 t.start()
@@ -294,20 +316,69 @@ class BatteryMonitorCLI(Loggable):
             and self.controllers
             and charging is not None
         ):
+            self._stop_animation_thread()
             log.debug("Not running animation: %s", charging)
             return
 
         has_secondary = len(self.controllers) > 1
         last = self.last_charging_state
         if has_secondary:
-            should_animate = charging != last
-        else:
-            should_animate = last is not None and charging != last
+            if self._animation_thread and self._animation_thread.is_alive():
+                if self._animation_state == charging:
+                    log.debug("Animation already running on secondary: %s", charging)
+                    return
+                log.debug(
+                    "Stopping animation (state change), state: %s -> %s",
+                    self._animation_state,
+                    charging,
+                )
+                self._stop_animation_thread()
 
+            should_animate = charging != last or self._animation_thread is None
+            if not should_animate:
+                log.debug(
+                    "Not running animation (%s controller rule), state: %s -> %s",
+                    "secondary",
+                    last,
+                    charging,
+                )
+                return
+
+            log.debug("Running animation: %s", charging)
+            args = self.args
+            controller = self.controllers[1]
+            stop_event = Event()
+            self._animation_stop = stop_event
+            self._animation_state = charging
+            log.debug(
+                "Running animation on secondary controller: %s, charging=%s",
+                controller,
+                charging,
+            )
+
+            t = Thread(
+                target=play_batt_direction_loop,
+                args=(controller,),
+                kwargs={
+                    "charging": charging,
+                    "stop_event": stop_event,
+                    "brightness": args.animation_brightness,
+                    "frame_duration": args.frame_duration,
+                },
+            )
+            try:
+                t.start()
+                self._animation_thread = t
+                self.threads.append(t)
+            except Exception as exc:  # pragma: no cover - hardware specific
+                log.warning("Failed to run animation on secondary: %s", exc)
+            return
+
+        should_animate = last is not None and charging != last
         if not should_animate:
             log.debug(
-                "Not running animation (%s controller rule), state: %s → %s",
-                "secondary" if has_secondary else "primary",
+                "Not running animation (%s controller rule), state: %s -> %s",
+                "primary",
                 last,
                 charging,
             )
@@ -321,13 +392,12 @@ class BatteryMonitorCLI(Loggable):
             "brightness": args.animation_brightness,
             "frame_duration": args.frame_duration,
             "direction": args.scroll_direction,
-            "loop": has_secondary,
+            "loop": False,
         }
 
-        controller = self.controllers[1] if has_secondary else self.controllers[0]
+        controller = self.controllers[0]
         log.debug(
-            "Running animation on %s controller: %s, charging=%s, loop=%s",
-            "secondary" if has_secondary else "primary",
+            "Running animation on primary controller: %s, charging=%s, loop=%s",
             controller,
             charging,
             opts["loop"],

--- a/ismf_battery_monitor/scripts/battery_monitor/main.py
+++ b/ismf_battery_monitor/scripts/battery_monitor/main.py
@@ -258,7 +258,10 @@ class BatteryMonitorCLI(Loggable):
                 self._animation_stop.set()
                 self._animation_thread.join(timeout=2)
                 if self._animation_thread.is_alive():
-                    log.warning("Animation thread did not stop within timeout.")
+                    log.warning(
+                        "Animation thread did not terminate within timeout; "
+                        "leaving references for potential later cleanup."
+                    )
                     return
 
         self._animation_thread = None
@@ -343,7 +346,7 @@ class BatteryMonitorCLI(Loggable):
                 )
                 self._stop_animation_thread()
 
-            should_animate = charging != last or self._animation_thread is None
+            should_animate = charging != last
             if not should_animate:
                 log.debug(
                     "Not running animation (%s controller rule), state: %s -> %s",
@@ -357,8 +360,8 @@ class BatteryMonitorCLI(Loggable):
             args = self.args
             controller = self.controllers[1]
             stop_event = Event()
-            self._animation_stop = stop_event
             self._animation_state = charging
+            self._animation_stop = stop_event
             log.debug(
                 "Running animation on secondary controller: %s, charging=%s",
                 controller,
@@ -376,9 +379,8 @@ class BatteryMonitorCLI(Loggable):
                 },
             )
             try:
-                t.start()
                 self._animation_thread = t
-                self.threads.append(t)
+                t.start()
             except Exception as exc:  # pragma: no cover - hardware specific
                 log.warning("Failed to run animation on secondary: %s", exc)
             return

--- a/ismf_battery_monitor/scripts/battery_monitor/main.py
+++ b/ismf_battery_monitor/scripts/battery_monitor/main.py
@@ -247,10 +247,19 @@ class BatteryMonitorCLI(Loggable):
         self._restore_controllers()
 
     def _stop_animation_thread(self) -> None:
+        log = self.method_logger
+
         if self._animation_thread and self._animation_thread.is_alive():
-            if self._animation_stop is not None:
+            if self._animation_stop is None:
+                log.warning(
+                    "Animation thread running without stop event; unable to request stop.",
+                )
+            else:
                 self._animation_stop.set()
-            self._animation_thread.join(timeout=2)
+                self._animation_thread.join(timeout=2)
+                if self._animation_thread.is_alive():
+                    log.warning("Animation thread did not stop within timeout.")
+                    return
 
         self._animation_thread = None
         self._animation_stop = None

--- a/ismf_battery_monitor/scripts/battery_monitor/main.py
+++ b/ismf_battery_monitor/scripts/battery_monitor/main.py
@@ -342,9 +342,8 @@ class BatteryMonitorCLI(Loggable):
         has_secondary = len(self.controllers) > 1
         last = self.last_charging_state
         if has_secondary:
-            # Note: The logic below relies on the check at line ~329 ensuring
-            # charging is not None. If refactored, ensure state comparison
-            # doesn't inadvertently match None == None on first call.
+            # Note: The logic below relies on the earlier guard ensuring charging is not None.
+            # If refactored, ensure state comparison doesn't inadvertently match None == None.
             if self._animation_thread and self._animation_thread.is_alive():
                 if self._animation_state == charging:
                     log.debug("Animation already running on secondary: %s", charging)


### PR DESCRIPTION
### Motivation
- Prevent conflicting/choppy animations on the secondary LED matrix that occur after unplug/plug transitions by avoiding overlapping animation playback.
- Ensure secondary animation threads can be cleanly stopped on state changes and during shutdown to avoid orphaned threads and device contention.
- Reduce redundant redraws on the secondary controller when animations are enabled to avoid visual glitches and concurrent drawing.

### Description
- Added a stoppable loop helper `play_batt_direction_loop` in `ismf_battery_monitor/animations.py` that plays the up/down battery animation repeatedly until a `stop_event` is set.
- In `BatteryMonitorCLI` added fields `self._animation_thread`, `self._animation_stop`, and `self._animation_state`, plus a `_stop_animation_thread` helper that signals and joins the secondary animation thread on shutdown or state changes.
- Reworked `_maybe_run_animation` to serialize secondary-controller animations by running a single stoppable thread for the secondary and to keep the primary animation behavior as a single-play (non-looping) run, and adjusted `_draw_scene` to only draw to the primary when `show_animations` is enabled and multiple controllers exist.
- Cleaned up logging formatting for controller-state messages to use ASCII arrows and clearer debug messages when animations are already running or being stopped.

### Testing
- No automated tests were run because the changes are hardware-dependent and affect runtime behavior with physical LED controllers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d443949f4832da6ba4032ec68d5af)

## Summary by Sourcery

Serialize battery animations across primary and secondary LED controllers and introduce a stoppable loop with proper cleanup for secondary animations.

New Features:
- Add a stoppable looping battery-direction animation helper that can be interrupted via a stop event.

Bug Fixes:
- Ensure secondary animation threads are cleanly stopped on shutdown or charging-state changes to prevent orphaned threads and choppy animations.
- Prevent conflicting animations by serializing secondary-controller playback and avoiding repeated triggers for the same charging state.

Enhancements:
- Manage secondary animation playback through a dedicated thread with explicit stop signaling and state tracking to avoid overlapping animations.
- Restrict scene drawing to the primary controller when animations are enabled with multiple controllers to reduce redundant redraws and contention.
- Periodically clean up finished worker threads in the battery monitor CLI to prevent unbounded thread accumulation.
- Improve logging messages and state-transition debug output for animation start/stop decisions.