### PR TITLE
Harden animation loop shutdown and cleanup

### DIFF
--- a/ismf_battery_monitor/animations.py
+++ b/ismf_battery_monitor/animations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from importlib import resources
+from threading import Event
 
 from easy_exit_calls import ExitCallHandler
 from is_matrix_forge.led_matrix.controller.helpers import find_leftmost, find_rightmost
@@ -148,6 +149,35 @@ def play_batt_down_animation(controller, *, brightness: int | None = None,
         frame_duration=frame_duration,
         loop=loop
     )
+
+
+def play_batt_direction_loop(
+    controller,
+    *,
+    charging: bool,
+    stop_event: Event,
+    brightness: int | None = None,
+    frame_duration: float = 1.0,
+) -> None:
+    ensure_thread_safety(controller)
+    if stop_event.is_set():
+        return
+    prev_brightness = getattr(controller, 'brightness', None)
+    if brightness is not None:
+        controller.set_brightness(brightness)
+
+    filename = 'batt_up.json' if charging else 'batt_down.json'
+    ani = _load_animation_from_package(filename)
+    ani.set_all_frame_durations(frame_duration)
+    ani.loop = False
+
+    try:
+        while not stop_event.is_set():
+            controller.clear()
+            ani.play(controller)
+    finally:
+        if prev_brightness is not None:
+            controller.set_brightness(prev_brightness)
 
 
 def drain_progress(

--- a/ismf_battery_monitor/scripts/battery_monitor/main.py
+++ b/ismf_battery_monitor/scripts/battery_monitor/main.py
@@ -14,7 +14,11 @@ from easy_exit_calls import ExitCallHandler
 
 from is_matrix_forge.led_matrix.controller.helpers import find_leftmost, find_rightmost
 from ismf_battery_monitor.log_engine import ROOT_LOGGER, Loggable
-from ...animations import play_batt_down_animation, play_batt_up_animation
+from ...animations import (
+    play_batt_direction_loop,
+    play_batt_down_animation,
+    play_batt_up_animation,
+)
 from ...controllers import get_cached_controllers
 from ...monitor import BatteryMonitor
 from ...scenes import get_composite_scene_for_battery_level
@@ -93,6 +97,9 @@ class BatteryMonitorCLI(Loggable):
 
         self.controllers: List[object] = []
         self.last_charging_state: Optional[bool] = None
+        self._animation_thread: Optional[Thread] = None
+        self._animation_stop: Optional[Event] = None
+        self._animation_state: Optional[bool] = None
 
         self.exit_handler = ExitCallHandler()
         self.exit_handler.register_handler(self._shutdown)
@@ -236,7 +243,29 @@ class BatteryMonitorCLI(Loggable):
         if self._monitor_started:
             self.monitor.stop()
 
+        self._stop_animation_thread()
         self._restore_controllers()
+
+    def _stop_animation_thread(self) -> None:
+        log = self.method_logger
+
+        if self._animation_thread and self._animation_thread.is_alive():
+            if self._animation_stop is None:
+                log.warning("Animation thread running without stop event; attempting join.")
+                self._animation_thread.join(timeout=2)
+            else:
+                self._animation_stop.set()
+                self._animation_thread.join(timeout=2)
+            if self._animation_thread.is_alive():
+                log.warning("Animation thread did not stop within timeout.")
+
+        self._animation_thread = None
+        self._animation_stop = None
+        self._animation_state = None
+
+    def _cleanup_finished_threads(self) -> None:
+        """Remove completed worker threads; animation thread is tracked separately."""
+        self._threads = [thread for thread in self._threads if thread.is_alive()]
 
     def _wait_for_stop(self) -> None:
         log = self.method_logger
@@ -261,6 +290,7 @@ class BatteryMonitorCLI(Loggable):
             return
 
         pct = status.battery_percent
+        self._cleanup_finished_threads()
         self._draw_scene(pct, status.charging)
         self._maybe_run_animation(status.charging)
         self._log_battery_level(pct)
@@ -277,7 +307,11 @@ class BatteryMonitorCLI(Loggable):
             charging_state=charging_state,
         )
 
-        for controller in self.controllers:
+        controllers = self.controllers
+        if getattr(self.args, "show_animations", False) and len(self.controllers) > 1:
+            controllers = [self.controllers[0]]
+
+        for controller in controllers:
             t = Thread(target=scene.draw, args=(controller,))
             try:
                 t.start()
@@ -294,20 +328,69 @@ class BatteryMonitorCLI(Loggable):
             and self.controllers
             and charging is not None
         ):
+            self._stop_animation_thread()
             log.debug("Not running animation: %s", charging)
             return
 
         has_secondary = len(self.controllers) > 1
         last = self.last_charging_state
         if has_secondary:
-            should_animate = charging != last
-        else:
-            should_animate = last is not None and charging != last
+            if self._animation_thread and self._animation_thread.is_alive():
+                if self._animation_state == charging:
+                    log.debug("Animation already running on secondary: %s", charging)
+                    return
+                log.debug(
+                    "Stopping animation (state change), state: %s -> %s",
+                    self._animation_state,
+                    charging,
+                )
+                self._stop_animation_thread()
 
+            should_animate = charging != last or self._animation_thread is None
+            if not should_animate:
+                log.debug(
+                    "Not running animation (%s controller rule), state: %s -> %s",
+                    "secondary",
+                    last,
+                    charging,
+                )
+                return
+
+            log.debug("Running animation: %s", charging)
+            args = self.args
+            controller = self.controllers[1]
+            stop_event = Event()
+            self._animation_stop = stop_event
+            self._animation_state = charging
+            log.debug(
+                "Running animation on secondary controller: %s, charging=%s",
+                controller,
+                charging,
+            )
+
+            t = Thread(
+                target=play_batt_direction_loop,
+                args=(controller,),
+                kwargs={
+                    "charging": charging,
+                    "stop_event": stop_event,
+                    "brightness": args.animation_brightness,
+                    "frame_duration": args.frame_duration,
+                },
+            )
+            try:
+                t.start()
+                self._animation_thread = t
+                self.threads.append(t)
+            except Exception as exc:  # pragma: no cover - hardware specific
+                log.warning("Failed to run animation on secondary: %s", exc)
+            return
+
+        should_animate = last is not None and charging != last
         if not should_animate:
             log.debug(
-                "Not running animation (%s controller rule), state: %s → %s",
-                "secondary" if has_secondary else "primary",
+                "Not running animation (%s controller rule), state: %s -> %s",
+                "primary",
                 last,
                 charging,
             )
@@ -321,13 +404,12 @@ class BatteryMonitorCLI(Loggable):
             "brightness": args.animation_brightness,
             "frame_duration": args.frame_duration,
             "direction": args.scroll_direction,
-            "loop": has_secondary,
+            "loop": False,
         }
 
-        controller = self.controllers[1] if has_secondary else self.controllers[0]
+        controller = self.controllers[0]
         log.debug(
-            "Running animation on %s controller: %s, charging=%s, loop=%s",
-            "secondary" if has_secondary else "primary",
+            "Running animation on primary controller: %s, charging=%s, loop=%s",
             controller,
             charging,
             opts["loop"],


### PR DESCRIPTION
### Motivation
- Prevent briefly flashing animations during rapid stop/start by avoiding starting loops when a stop event is already set. 
- Make animation thread shutdown more robust and observable when threads fail to stop cleanly. 
- Avoid leaking finished worker threads from the thread list so background bookkeeping stays accurate. 
- Ensure secondary-controller animations are serialized and do not overlap with primary draws when `show_animations` is enabled.

### Description
- Added an early-return check in `play_batt_direction_loop` to skip starting the loop if the passed `stop_event` is already set. 
- Reworked `_stop_animation_thread` to attempt a `join(timeout=2)` even when `_animation_stop` is missing, and to always clear `_animation_thread`, `_animation_stop`, and `_animation_state` fields. 
- Added `_cleanup_finished_threads` (with docstring noting the animation thread is tracked separately) and call it from `_handle_status` to prune completed worker threads. 
- Adjusted animation orchestration in `_maybe_run_animation` and `_draw_scene` to serialize secondary animations using a dedicated thread started with `play_batt_direction_loop`, track `_animation_thread`/`_animation_stop`/`_animation_state`, and restrict primary redraws when `show_animations` and multiple controllers exist.

### Testing
- No automated tests were run because the changes are hardware-dependent and affect runtime behavior with physical LED controllers. 
- No CI/unit test results to report for this change. 
- Hardware/integration testing was not performed as part of this PR. 
- Runtime behavior changes were implemented defensively to minimize regressions during live use.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d443949f4832da6ba4032ec68d5af)

## Summary by Sourcery

Improve robustness and coordination of battery animation threads and controller rendering.

New Features:
- Introduce a dedicated play_batt_direction_loop helper to drive charging/discharging animations in a stoppable loop via a threading.Event.

Bug Fixes:
- Prevent starting new animations when a stop event is already set to avoid brief flashing during rapid start/stop cycles.
- Ensure finished worker threads are removed from the internal thread list so background bookkeeping reflects only live threads.

Enhancements:
- Track a single active animation thread, its stop event, and the current animation state on the monitor instance to manage lifecycle and avoid overlapping animations.
- Harden animation shutdown by centralizing thread stopping logic, always attempting a timed join, and clearing animation-related state even on failure.
- Serialize secondary-controller animations onto a dedicated animation thread and restrict primary redraws when animations are enabled and multiple controllers are present.